### PR TITLE
Accept-encoding gzip etc.

### DIFF
--- a/index.php
+++ b/index.php
@@ -401,7 +401,8 @@ do {
 
     $_request_headers .= " HTTP/1.0\r\n";
     $_request_headers .= 'Host: ' . $_url_parts['host'] . $_url_parts['port_ext'] . "\r\n";
-
+    $_request_headers .= 'Accept-Encoding: ' . "\r\n";
+	
     if (isset($_SERVER['HTTP_USER_AGENT'])) {
         $_request_headers .= 'User-Agent: ' . $_SERVER['HTTP_USER_AGENT'] . "\r\n";
     }


### PR DESCRIPTION
Requesting a page from a site that automatically encodes page content using deflate or gzip will result in a failure to proxy the page successfully (its compressed, not raw text)
Sending the extra header stating you accept no encoding methods (empty string) will _request_ that no compression is used in the response. 
see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
mh
