### PR TITLE
At allow 304 make browser faster but need correct

### DIFF
--- a/include/settings.php
+++ b/include/settings.php
@@ -26,9 +26,10 @@ $_flags             = array
                         'remove_scripts'  => 0,
                         'accept_cookies'  => 1,
                         'show_images'     => 1,
-                        'show_referer'    => 1,
-                        'rotate13'        => 0,
-                        'base64_encode'   => 1,
+
+                        'show_referer'    => 0,
+                        'rotate13'        => 1,
+                        'base64_encode'   => 0,
                         'strip_meta'      => 0,
                         'strip_title'     => 0,
                         'session_cookies' => 0,


### PR DESCRIPTION
This make much more faster after Allow 304 setting. And correcting encoding. You can test it here zenos.tk. 
